### PR TITLE
More fixes

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,7 +26,7 @@
         {
             "label": "Server",
             "type": "process",
-            "command": "godot3",
+            "command": "godot3-console",
             "args": [
                 "--server"
             ],
@@ -37,7 +37,7 @@
         {
             "label": "Client Host",
             "type": "process",
-            "command": "godot3",
+            "command": "godot3-console",
             "args": [
                 "--host"
             ],
@@ -48,7 +48,7 @@
         {
             "label": "Client Join",
             "type": "process",
-            "command": "godot3",
+            "command": "godot3-console",
             "args": [
                 "--join",
                 "127.0.0.1"
@@ -60,7 +60,7 @@
         {
             "label": "Client Join 2",
             "type": "process",
-            "command": "godot3",
+            "command": "godot3-console",
             "args": [
                 "--join",
                 "127.0.0.1"
@@ -72,7 +72,7 @@
         {
             "label": "Client Join 3",
             "type": "process",
-            "command": "godot3",
+            "command": "godot3-console",
             "args": [
                 "--join",
                 "127.0.0.1"
@@ -84,7 +84,7 @@
         {
             "label": "Client Join 4",
             "type": "process",
-            "command": "godot3",
+            "command": "godot3-console",
             "args": [
                 "--join",
                 "127.0.0.1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ Types of changes:
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix ready status desyncing when going back to setup lobby
+
+### Changed
+
+- Always go back to the setup lobby after a multiplayer race
+- Late joining players will now automatically stop spectating
+
 ## [0.14.1] - 2026-04-09
 
 ### Fixed

--- a/client/client_network.gd
+++ b/client/client_network.gd
@@ -24,6 +24,7 @@ var host_player_id := 0
 var player_list := {}
 var game_options := {}
 var game_id := ""
+var late_joined := false
 
 signal host_changed(old_host_id, new_host_id)
 signal player_list_changed(old_player_list, new_player_list)
@@ -238,6 +239,7 @@ remote func receive_game_info(
 remote func receive_late_join_info(game_seed: int, time: float) -> void:
 	if is_rpc_from_server() == false:
 		return
+	late_joined = true
 	change_scene_to_world()
 	var world = get_node_or_null("World")
 	if world:

--- a/client/menu/setup/setup.gd
+++ b/client/menu/setup/setup.gd
@@ -44,7 +44,12 @@ func _ready() -> void:
 		if not Network.Client.player_list.empty():
 			populate_players({}, Network.Client.player_list)
 			var player_id = multiplayer.get_network_unique_id()
-			set_is_spectating(Network.Client.player_list[player_id].spectate)
+			if Network.Client.late_joined:
+				# Disable spectating automatically for late joiners
+				set_is_spectating(false)
+				Network.Client.send_player_spectate_change(is_spectating)
+			else:
+				set_is_spectating(Network.Client.player_list[player_id].spectate)
 
 	# Need to defer this or the menu animation hides it
 	$StartButton.call_deferred("grab_focus")

--- a/client/ui/ui.gd
+++ b/client/ui/ui.gd
@@ -107,9 +107,12 @@ func show_leaderboard(player_list: Array) -> void:
 		$Leaderboard.add_player(player.name, player.colour, place_text, player.progress, time)
 
 	if Network.Client.is_host():
-		$Leaderboard/Footer/RestartButton.show()
-		$Leaderboard/Footer/RestartButton.grab_focus()
 		$Leaderboard/Footer/NewRaceButton.show()
+		if Network.Client.is_singleplayer:
+			$Leaderboard/Footer/RestartButton.show()
+			$Leaderboard/Footer/RestartButton.grab_focus()
+		else:
+			$Leaderboard/Footer/NewRaceButton.grab_focus()
 	else:
 		$Leaderboard/Footer/RestartButton.hide()
 		$Leaderboard/Footer/NewRaceButton.hide()

--- a/server/server_network.gd
+++ b/server/server_network.gd
@@ -166,6 +166,8 @@ func stop_server() -> void:
 func change_scene_to_setup() -> void:
 	# Flush out old player state
 	player_state_collection.clear()
+	# Make sure ready is reset before changing scene to repopulate player list
+	reset_players_ready()
 	$StateProcessing.running = false
 	change_scene("res://server/setup.tscn")
 
@@ -529,6 +531,7 @@ remote func receive_start_game_request() -> void:
 
 
 func reset_players_ready() -> void:
+	Logger.print(self, "Resetting all players ready status to false")
 	for player_id in player_list.keys():
 		player_list[player_id].ready = false
 

--- a/server/setup.gd
+++ b/server/setup.gd
@@ -7,11 +7,6 @@ func _ready() -> void:
 	result = Network.Server.connect("player_ready_changed", self, "_on_player_ready_changed")
 	assert(result == OK)
 
-	# Reset everyone's ready status every time we enter setup
-	Network.Server.reset_players_ready()
-	for player_id in Network.Server.player_list.keys():
-		Network.Server.send_player_ready_update(player_id, false)
-
 
 func _on_player_ready_changed(player_id: int, is_ready: bool) -> void:
 	Network.Server.player_list[player_id].ready = is_ready


### PR DESCRIPTION
### Fixed

- Fix ready status desyncing when going back to setup lobby

### Changed

- Always go back to the setup lobby after a multiplayer race
- Late joining players will now automatically stop spectating